### PR TITLE
Fix issue where Dispose() called after source terminated potentially violates spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,11 @@ const subscribe = (listener = {}) => source => {
     }
     if (t === 1 && next) next(d);
     if (t === 1 || t === 0) talkback(1);  // Pull
-    if (t === 2 && !d && complete) complete();
-    if (t === 2 && !!d && error) error( d );
+    if (t === 2) {
+      talkback = null;
+      if (!d && complete) complete();
+      if (!!d && error) error( d );
+    }
   });
 
   const dispose = () => {


### PR DESCRIPTION
Spec says: `A callbag MUST NOT be delivered data after it has been terminated`

As I understand it, for callbags to work in concert all callbags must either:
1) not send 'terminate' to sources/sinks after said source/sink notifies it has terminated
2) guard against case where callbag has notified sources/sinks of termination and is itself subsequently terminated 

I expect 1) - though perhaps @staltz should weigh in...

If 2) then I believe this issue should be raised with @Andarist in [callbag-remember](https://github.com/Andarist/callbag-remember) since it doesn't guard against that case.

Example: https://stackblitz.com/edit/typescript-6w7v6u?file=index.ts

```
import pipe from "callbag-pipe";
import of from "callbag-of";
import subscribe from "callbag-subscribe";
import remember from "callbag-remember";

// once `of` arguments are exhausted, it sends dispose signal to its sink (remember)
const num$ = remember(of(1));

const cancelSubscription = pipe(
  num$,
  subscribe(value => console.log(value))
);

setTimeout(
  () =>
    // when subscription is canceled, it sends dispose signal to its source (remember)
    cancelSubscription(),
  100
);

// remember throws error after recieving dispose signal from both source and sink
```